### PR TITLE
Feature: Add Core Computer Science References and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Throughout my career, my favorite question to ask fellow software engineers and 
 
 
  - [Books Every Software Engineer Should Read](fundamental.md)
+  - [Core Computer Science](core.md)
  - [JavaScript](javascript.md)
  - [Management](management.md)

--- a/core.md
+++ b/core.md
@@ -1,0 +1,13 @@
+# Core
+
+### Reference Sites
+- [Refactoring Guru](https://refactoring.guru/)
+
+### Books
+- [Introduction to Algorithms, 3rd Edition](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844/)
+- [Design Patterns](https://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional-ebook/dp/B000SEIBB8)
+- [Refactoring 1st Edition](https://www.amazon.com/Refactoring-Improving-Design-Existing-Code/dp/0201485672/) [2nd Edition](https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature-ebook/dp/B07LCM8RG2/)
+
+### Classes
+- [MIT - Introductions to Algorithms, Fall 2011](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/)
+- [Data Structures and Algorithms in JavaScript](https://frontendmasters.com/courses/data-structures-algorithms/)

--- a/fundamental.md
+++ b/fundamental.md
@@ -6,11 +6,11 @@
 - [Designing With Web Standard](https://www.amazon.com/Designing-Web-Standards-Jeffrey-Zeldman/dp/0735712018)
 
 ### Fundamentals
-- [Introduction to Algorithms](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844/ref=sr_1_4?keywords=Algorithms&qid=1582159891&s=books&sr=1-4)
-- [Design Patterns](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612/ref=asc_df_0201633612/?tag=hyprod-20&linkCode=df0&hvadid=312280575053&hvpos=1o1&hvnetw=g&hvrand=6874055354669084155&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9004156&hvtargid=pla-395340045790&psc=1)
+- [Introduction to Algorithms, 3rd Edition](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844/)
+- [Design Patterns](https://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional-ebook/dp/B000SEIBB8)
 
 ### Code Quality & Habits
-- [Refactoring](https://www.amazon.com/Refactoring-Improving-Design-Existing-Code/dp/0201485672/ref=pd_sbs_14_1/141-4748295-6711835?_encoding=UTF8&pd_rd_i=0201485672&pd_rd_r=d5460e08-9b16-4f33-9f47-f1d37ea167ed&pd_rd_w=pLmUN&pd_rd_wg=zr6vM&pf_rd_p=7cd8f929-4345-4bf2-a554-7d7588b3dd5f&pf_rd_r=A37A0ZN9PDY03NZYBMQ2&psc=1&refRID=A37A0ZN9PDY03NZYBMQ2)
+- [Refactoring 1st Edition](https://www.amazon.com/Refactoring-Improving-Design-Existing-Code/dp/0201485672/) | [2nd Edition](https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature-ebook/dp/B07LCM8RG2/)
 - [The Pragmatic Programmer](https://www.amazon.com/Pragmatic-Programmer-Journeyman-Master/dp/020161622X/ref=pd_sbs_14_1/141-4748295-6711835?_encoding=UTF8&pd_rd_i=020161622X&pd_rd_r=c1f52aa1-b996-4333-b350-9fe3eeb7fcb1&pd_rd_w=vz5Bd&pd_rd_wg=KCx6l&pf_rd_p=7cd8f929-4345-4bf2-a554-7d7588b3dd5f&pf_rd_r=RXZQCZSG3EHR89W8EWPQ&psc=1&refRID=RXZQCZSG3EHR89W8EWPQ)
 - [Clean Code](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882/ref=pd_bxgy_img_2/141-4748295-6711835?_encoding=UTF8&pd_rd_i=0132350882&pd_rd_r=9552d7f9-4d1c-4dc1-9411-42a4c52e2ddb&pd_rd_w=HazYj&pd_rd_wg=KCX6Z&pf_rd_p=fd08095f-55ff-4a15-9b49-4a1a719225a9&pf_rd_r=Y2VXTNV2KX22YVS2W6QA&psc=1&refRID=Y2VXTNV2KX22YVS2W6QA)
 

--- a/javascript.md
+++ b/javascript.md
@@ -1,7 +1,14 @@
 # JavaScript
 
+### Reference Sites
+- [JavaScript Info](https://javascript.info/)
+
 ### Books
 - [Eloquent JavaScript](https://eloquentjavascript.net/)
 - [JavaScript For Impatient Programmers](https://exploringjs.com/impatient-js/)
 - [Deep JavaScript](https://exploringjs.com/deep-js/)
 - [You Don't Know JS Yet](https://github.com/getify/You-Dont-Know-JS)
+
+### Classes
+
+- [Frontend Master](https://frontendmasters.com/)


### PR DESCRIPTION
### Summary
Add Core Computer Science References and update links on other pages to not include parameters for amazon. Also, add Frontend Masters as a general course class to JavaScript. All courses on Frontend Masters are recommended for JS engineers at time of publish.